### PR TITLE
bump-ghc

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -1,6 +1,7 @@
 # For more information, see: https://github.com/commercialhaskell/stack/blob/release/doc/yaml_configuration.md
 
 # Specifies the GHC version and set of packages available (e.g., lts-3.5, nightly-2015-09-21, ghc-7.10.2)
+# https://docs.haskellstack.org/en/stable/GUIDE/#resolvers-and-changing-your-compiler-version
 resolver: lts-16.16
 
 # Local packages, usually specified by relative directory name


### PR DESCRIPTION
This pr is linked to an issue.

I found the doc, now I need to run the build with various resolvers.

Once the latest and stable are working a decision could be made about which versions could be dropped.